### PR TITLE
docs: add Canada new grad jobs resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -709,6 +709,8 @@ Connect and seek advice from a growing network of fellow students and new grads.
 
 <img src="images/more-resources.png" alt="Jobs and templates in our other repos.">
 
+For Canada-specific student and recent-grad searches, [Hanzilla Jobs](https://jobs.hanzilla.co/new-grad/) is a free daily-updated board for Canadian new-grad, junior, internship, co-op, and entry-level roles across tech, engineering, business, finance, sciences, arts/humanities, and other fields.
+
 <p align="center">
   <a href="https://github.com/zapplyjobs/New-Grad-Software-Engineering-Jobs-2026"><img src="images/repo-sej.png" alt="Software Engineering Jobs" height="40"></a>
   &nbsp;&nbsp;


### PR DESCRIPTION
## Summary
- Adds Hanzilla Jobs as a Canada-specific companion resource in the README's resources section.
- Links directly to the new-grad landing page for Canadian new-grad, junior, internship, co-op, and entry-level roles across fields.

## Why
This repo focuses heavily on new-grad job discovery, while Hanzilla is specifically for Canadian students/recent grads and keeps Canada-specific roles updated daily. It should be useful for readers looking for Canadian opportunities alongside the existing resources.

## Test plan
- README-only change
- `git diff --check`
